### PR TITLE
Allow guest checkout URLs and form actions

### DIFF
--- a/src/controllers/CheckoutController.php
+++ b/src/controllers/CheckoutController.php
@@ -22,6 +22,9 @@ use yii\web\Response;
  */
 class CheckoutController extends Controller
 {
+    /**
+     * @inheritdoc
+     */
     protected array|bool|int $allowAnonymous = true;
 
     /**

--- a/src/controllers/CheckoutController.php
+++ b/src/controllers/CheckoutController.php
@@ -22,6 +22,8 @@ use yii\web\Response;
  */
 class CheckoutController extends Controller
 {
+    protected array|bool|int $allowAnonymous = true;
+
     /**
      * @inheritdoc
      */
@@ -41,6 +43,10 @@ class CheckoutController extends Controller
         $request = Craft::$app->getRequest();
 
         $currentUser = Craft::$app->getUser()->getIdentity();
+
+        if ($currentUser === null) {
+            $currentUser = false;
+        }
 
         // process line items
         $postLineItems = $request->getRequiredBodyParam('lineItems');

--- a/src/services/Checkout.php
+++ b/src/services/Checkout.php
@@ -58,8 +58,7 @@ class Checkout extends Component
         ?string $successUrl = null,
         ?string $cancelUrl = null,
         ?array $params = null,
-    ): string
-    {
+    ): string {
         $customer = null;
         if ($user === false) {
             $customer = false;


### PR DESCRIPTION
### Description
Currently, the `Checkout::getCheckoutUrl()` method and the `CheckoutController::actionCheckout()` endpoint both require that there be an actual Craft user to generate the session.

This PR updates the functionality to allow guest checkouts via the service method and controller action.

Due to the nature of how the method arguments are set it is a bit odd having to pass `false`, this is because currently, we are treating `null` as somewhat of a fallback which will try and seek out the user.
