### PR TITLE
After syncing customer’s email to Stripe, ensure customer data record is updated straight away.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -55,6 +55,7 @@ use craft\stripe\web\twig\CraftVariableBehavior;
 use craft\stripe\web\twig\Extension;
 use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
+use Stripe\Exception\ApiErrorException;
 use yii\base\Event;
 use yii\base\InvalidConfigException;
 use yii\base\ModelEvent;
@@ -551,8 +552,12 @@ class Plugin extends BasePlugin
                     if ($customers->isNotEmpty()) {
                         $client = $this->getApi()->getClient();
                         foreach ($customers->all() as $customer) {
-                            $updatedCustomer = $client->customers->update($customer->stripeId, ['email' => $newEmail]);
-                            $this->getCustomers()->createOrUpdateCustomer($updatedCustomer);
+                            try {
+                                $updatedCustomer = $client->customers->update($customer->stripeId, ['email' => $newEmail]);
+                                $this->getCustomers()->createOrUpdateCustomer($updatedCustomer);
+                            } catch (ApiErrorException $e) {
+                                Craft::error("Unable to update customer's email in Stripe: {$e->getMessage()}", 'stripe');
+                            }
                         }
                     }
                 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -551,7 +551,8 @@ class Plugin extends BasePlugin
                     if ($customers->isNotEmpty()) {
                         $client = $this->getApi()->getClient();
                         foreach ($customers->all() as $customer) {
-                            $client->customers->update($customer->stripeId, ['email' => $newEmail]);
+                            $updatedCustomer = $client->customers->update($customer->stripeId, ['email' => $newEmail]);
+                            $this->getCustomers()->createOrUpdateCustomer($updatedCustomer);
                         }
                     }
                 }


### PR DESCRIPTION
### Description
When you edit a user’s email and the logic to update a customer’s email in Stripe kicks in, we need to ensure the customer data record(s) (`stripe_customerdata` table) is also updated straight away.


### Related issues
#12 
