### PR TITLE
Feature/17 add stripe event

### DIFF
--- a/src/controllers/WebhooksController.php
+++ b/src/controllers/WebhooksController.php
@@ -43,6 +43,7 @@ class WebhooksController extends Controller
 
         return parent::beforeAction($action);
     }
+
     /**
      * Handle incoming Stripe webhook event
      *
@@ -52,13 +53,11 @@ class WebhooksController extends Controller
     {
         $apiService = Plugin::getInstance()->getApi();
         $webhookService = Plugin::getInstance()->getWebhooks();
-        //$client = $apiService->getClient();
         $webhookSigningSecret = $apiService->getWebhookSigningSecret();
 
         // verify
         $payload = @file_get_contents('php://input');
         $signatureHeader = $_SERVER['HTTP_STRIPE_SIGNATURE'];
-        //$event = null;
 
         try {
             $event = Webhook::constructEvent(

--- a/src/controllers/WebhooksController.php
+++ b/src/controllers/WebhooksController.php
@@ -75,10 +75,14 @@ class WebhooksController extends Controller
             return $this->asRaw('Err');
         }
 
+        $this->response->setStatusCode(200);
+        // as per https://docs.stripe.com/webhooks#acknowledge-events-immediately - send response asap
+        $this->response->sendAndClose();
+
         // Handle the event
         $webhookService->processEvent($event);
 
-        $this->response->setStatusCode(200);
+        // leaving this in even after sendAndClose() so that the response type matches
         return $this->asRaw('OK');
     }
 

--- a/src/events/StripeEvent.php
+++ b/src/events/StripeEvent.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\stripe\events;
+
+use Stripe\Event as StripeEventObject;
+use yii\base\Event;
+
+/**
+ * Event triggered once an event sent by Stripe is received and after the plugin is done processing it.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 1.2.0
+ */
+class StripeEvent extends Event
+{
+    /**
+     * @var StripeEventObject The event from Stripe
+     */
+    public StripeEventObject $stripeEvent;
+}

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -20,6 +20,7 @@ class Webhooks extends Component
 {
     /**
      * @event StripeWebhookEvent Event triggered once an event from Stripe has been received (but after the plugin had a chance to process it too).
+     * @since 1.2.0
      *
      * ---
      *

--- a/src/services/Webhooks.php
+++ b/src/services/Webhooks.php
@@ -7,8 +7,8 @@
 
 namespace craft\stripe\services;
 
+use craft\stripe\events\StripeEvent;
 use craft\stripe\Plugin;
-use Stripe\Stripe;
 use yii\base\Component;
 
 /**
@@ -18,6 +18,34 @@ use yii\base\Component;
  */
 class Webhooks extends Component
 {
+    /**
+     * @event StripeWebhookEvent Event triggered once an event from Stripe has been received (but after the plugin had a chance to process it too).
+     *
+     * ---
+     *
+     * ```php
+     * use craft\stripe\events\StripeWebhookEvent;
+     * use craft\stripe\services\Webhooks;
+     * use yii\base\Event;
+     *
+     * Event::on(
+     *     Webhooks::class,
+     *     Webhooks::EVENT_STRIPE_EVENT,
+     *     function(StripeWebhookEvent $event) {
+     *         $stripeEvent = $event->stripeEvent;
+     *         $eventObject = $stripeEvent->data->object;
+     *         // process the event based on its type
+     *         switch ($stripeEvent->type) {
+     *             case 'product.created':
+     *                 $productStripeId = $eventObject->id;
+     *                 // do something
+     *         }
+     *     }
+     * );
+     * ```
+     */
+    public const EVENT_STRIPE_EVENT = 'stripeEvent';
+
     /**
      * Process events received from Stripe
      *
@@ -97,6 +125,15 @@ class Webhooks extends Component
             case 'invoice.deleted':
                 $plugin->getInvoices()->deleteInvoiceByStripeId($eventObject->id);
                 break;
+            default:
+                // do nothing
+                break;
         }
+
+
+        $stripeEvent = new StripeEvent([
+            'stripeEvent' => $event,
+        ]);
+        $this->trigger(self::EVENT_STRIPE_EVENT, $stripeEvent);
     }
 }


### PR DESCRIPTION
### Description
When a webhook is created via Control Panel > Stripe > Webhooks, it’s created with the following events enabled: https://github.com/craftcms/stripe/blob/1.1.0/src/controllers/WebhooksController.php#L147-L176. Currently, the plugin listens and reacts to them but doesn’t expose those events to other plugins and modules.

This PR adds a `StripeEvent` event and `craft\stripe\services\Webhooks::EVENT_STRIPE_EVENT` so that modules and plugins can also listen to the events sent by Stripe that the plugin already listens to.

It also ensures that the successful response (200) is sent back to Stripe asap before the event starts being processed (as per [the docs](https://docs.stripe.com/webhooks#acknowledge-events-immediately)).

The event is called after the Stripe plugin has processed the incoming event(s).

If you need to listen to other events, you can either adjust the webhook configuration in Stripe’s dashboard to enable more events or create a separate webhook and implement your own mechanism for handling the events coming from Stripe.

How to use: 
```
use craft\stripe\services\Webhooks;

Event::on(
   Webhooks::class,
   Webhooks::EVENT_STRIPE_EVENT,
    function(StripeEvent $event) {
        $stripeEvent = $event->stripeEvent;
        $eventObject = $stripeEvent->data->object;
        // process the event based on its type
        switch ($stripeEvent->type) {
            case 'product.created':
                $productStripeId = $eventObject->id;
                // do something
        }
    }
);
```

### Related issues
#17 
