### PR TITLE
fix getting default price for a product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes for Stripe
 
+## Unreleased
+- Fixed getting a default price for a Product element. ([#40](https://github.com/craftcms/stripe/pull/40))
+
 ## 1.2.0 - 2024-11-06
 
 > [!NOTE]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes for Stripe
 
 ## Unreleased
+
 - Fixed getting a default price for a Product element. ([#40](https://github.com/craftcms/stripe/pull/40))
 
 ## 1.2.0 - 2024-11-06

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -596,15 +596,21 @@ class Product extends Element
     public function getDefaultPrice(): Price|null
     {
         if (!isset($this->_defaultPrice)) {
-            if ($this->getData()['default_price'] === null) {
+            $defaultPriceId = $this->getData()['default_price'];
+            if ($defaultPriceId === null) {
                 return null;
+            }
+
+            // depending on whether we're expanding a default_price when getting a product from Stripe, this will be a string or an array
+            if (is_array($defaultPriceId)) {
+                $defaultPriceId = $defaultPriceId['id'];
             }
 
             /** @var ElementCollection<int|string, Price> $prices */
             $prices = $this->getPrices();
 
             $price = $prices
-                ->filter(fn(Price $price) => $price->stripeId === $this->getData()['default_price'])
+                ->filter(fn(Price $price) => $price->stripeId === $defaultPriceId)
                 ->first();
 
             if (!$price) {


### PR DESCRIPTION
### Description
Fixes getting a default price for a Product element.

Depending on whether we’re expanding a `default_price` when getting a product from Stripe, this will be a string or an array.


### Related issues
#40 
