### PR TITLE
don't use null when specifying generated columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Stripe
 
+## Unreleased
+
+- Fixed an issue that could occur when installing or running migration on MariaDB. ([#51](https://github.com/craftcms/stripe/issues/51))
+
 ## 1.2.0.2 - 2024-11-08
 
 - Fixed a PHP error that could occur when saving a new user.

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -193,7 +193,7 @@ class Install extends Migration
         // latestInvoiceId
         $this->execute("ALTER TABLE " . Table::SUBSCRIPTIONDATA . " ADD COLUMN " .
             $db->quoteColumnName('latestInvoiceId') . " VARCHAR(255) GENERATED ALWAYS AS (" .
-            $qb->jsonExtract('data', ['latest_invoice']) . ") STORED NULL;");
+            $qb->jsonExtract('data', ['latest_invoice']) . ") STORED;");
         // startDate
         $this->execute("ALTER TABLE " . Table::SUBSCRIPTIONDATA . " ADD COLUMN " .
             $db->quoteColumnName('startDate') . " VARCHAR(255) GENERATED ALWAYS AS (" .

--- a/src/migrations/m240819_121818_loosen_aux_data_uniq.php
+++ b/src/migrations/m240819_121818_loosen_aux_data_uniq.php
@@ -27,7 +27,7 @@ class m240819_121818_loosen_aux_data_uniq extends Migration
         // Step 3: Recreate the virtual column as nullable: https://docs.stripe.com/api/subscriptions/object#subscription_object-latest_invoice
         $this->execute("ALTER TABLE " . $tableName . " ADD COLUMN " .
             $this->db->quoteColumnName('[[latestInvoiceId]]') . " VARCHAR(255) GENERATED ALWAYS AS (" .
-            $this->db->getQueryBuilder()->jsonExtract('data', ['latest_invoice']) . ") STORED NULL");
+            $this->db->getQueryBuilder()->jsonExtract('data', ['latest_invoice']) . ") STORED");
 
         // Step 4: Create a new non-unique index
         $this->createIndex(null, $tableName, ['latestInvoiceId'], unique: false);


### PR DESCRIPTION
### Description
Don’t use `null` when specifying stored generated columns. This change won’t affect MySQL and PosgreSQL if the migration was already run (or the plugin was installed with the previous version of this generated column), but it will allow the migration (or installation) to run successfully on MariaDB.


### Related issues
#51 
