### PR TITLE
Bugfix/59 sort options without link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Stripe
 
+## Unreleased
+
+- Fixed a bug where the products index page gave impression that it was possible to sort by Link. ([#59](https://github.com/craftcms/stripe/issues/59))
+
 ## 1.3.0 - 2024-11-19
 
 - Stripe now requires Craft CMS 5.5.0 or later.

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -293,6 +293,7 @@ class Product extends Element
         $sortOptions = parent::defineSortOptions();
 
         unset($sortOptions['stripeEdit']);
+        unset($sortOptions['link']);
 
         $sortOptions['title'] = self::displayName();
 


### PR DESCRIPTION
### Description
Disallow sorting products element index by Link.


### Related issues
#59 
