### PR TITLE
additional permissions checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Stripe
 
+## Unreleased
+
+- Fixed a bug where, in certain cases, it was possible to access a Subscription element in a slideout without having permission to access the Stripe plugin. ([#61](https://github.com/craftcms/stripe/pull/61))
+- Fixed a bug where the “Sync from Stripe” user menu item was shown even if user didn't permission to access the Stripe plugin. ([#61](https://github.com/craftcms/stripe/pull/61)) 
+
 ## 1.3.0 - 2024-11-19
 
 - Stripe now requires Craft CMS 5.5.0 or later.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 - Fixed a bug where, in certain cases, it was possible to access a Subscription element in a slideout without having permission to access the Stripe plugin. ([#61](https://github.com/craftcms/stripe/pull/61))
 - Fixed a bug where the “Sync from Stripe” user menu item was shown even if user didn't permission to access the Stripe plugin. ([#61](https://github.com/craftcms/stripe/pull/61))
 
-
 ## 1.3.0 - 2024-11-19
 
 - Stripe now requires Craft CMS 5.5.0 or later.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -577,7 +577,7 @@ class Plugin extends BasePlugin
             Element::EVENT_DEFINE_ACTION_MENU_ITEMS,
             function(DefineMenuItemsEvent $event) {
                 $sender = $event->sender;
-                if ($email = $sender->email) {
+                if ($email = $sender->email && Craft::$app->getUser()->checkPermission('accessPlugin-stripe')) {
                     $customers = Plugin::getInstance()->getApi()->fetchAllCustomers(['email' => $email]);
                     if ($customers) {
                         $stripeIds = collect($customers)->pluck('id');

--- a/src/controllers/CustomersController.php
+++ b/src/controllers/CustomersController.php
@@ -7,6 +7,7 @@
 
 namespace craft\stripe\controllers;
 
+use Craft;
 use craft\controllers\EditUserTrait;
 use craft\elements\User;
 use craft\helpers\Cp;
@@ -56,6 +57,7 @@ class CustomersController extends Controller
             'context' => 'embedded-index',
             'jsSettings' => [
                 'criteria' => ['userId' => $user->id],
+                'static' => !Craft::$app->getUser()->checkPermission('editUsers'),
             ],
         ]);
 

--- a/src/elements/Subscription.php
+++ b/src/elements/Subscription.php
@@ -410,7 +410,7 @@ class Subscription extends Element
      */
     public function canView(User $user): bool
     {
-        return true;
+        return parent::canView($user) || $user->can('accessPlugin-stripe');
     }
 
     /**


### PR DESCRIPTION
### Description
Check if a user has permission to access the Stripe plugin before:
- adding “Sync from Stripe” user menu item
- allowing to view subscriptions (e.g. when trying to view a subscription in a slideout)

Check if a user has permission to edit users, and if not, render the subscription embedded index on the User edit page in a static mode.


### Related issues
n/a
