### PR TITLE
Bugfix/62 webhook settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Stripe
 
+## Unreleased
+
+- Fixed a bug where the Webhook Signing Secret and ID were showing as parsed on the Webhooks page. ([#62](https://github.com/craftcms/stripe/issues/62))
+
 ## 1.3.0 - 2024-11-19
 
 - Stripe now requires Craft CMS 5.5.0 or later.

--- a/src/controllers/WebhooksController.php
+++ b/src/controllers/WebhooksController.php
@@ -108,8 +108,8 @@ class WebhooksController extends Controller
 
         $webhookInfo = [];
         $hasWebhook = true;
-        $webhookId = App::parseEnv($webhookRecord->webhookId);
-        $webhookSigningSecret = App::parseEnv($webhookRecord->webhookSigningSecret);
+        $webhookId = $webhookRecord->webhookId;
+        $webhookSigningSecret = $webhookRecord->webhookSigningSecret;
 
         if (!empty($webhookId)) {
             try {


### PR DESCRIPTION
### Description
Don’t parse the webhook signing secret and ID when displaying them on the webhooks page.


### Related issues
#62 
