### PR TITLE
parse webhook id

### DIFF
--- a/src/controllers/WebhooksController.php
+++ b/src/controllers/WebhooksController.php
@@ -112,11 +112,12 @@ class WebhooksController extends Controller
         $webhookSigningSecret = $webhookRecord->webhookSigningSecret;
 
         if (!empty($webhookId)) {
+            $parsedWebhookId = App::parseEnv($webhookRecord->webhookId);
             try {
-                $response = $this->getWebhookInfo($plugin, $webhookId);
+                $response = $this->getWebhookInfo($plugin, $parsedWebhookId);
                 $webhookInfo = $response->toArray();
             } catch (\Exception $e) {
-                Craft::error("Couldn't retrieve webhook with ID $webhookId: " . $e->getMessage());
+                Craft::error("Couldn't retrieve webhook with ID $parsedWebhookId: " . $e->getMessage());
                 $hasWebhook = false;
             }
         } else {


### PR DESCRIPTION
### Description
Missed from PR #63. We need to parse the `webhookId` before use, just like we parse other settings.


### Related issues
#62 
