### PR TITLE
Bugfix/check for apikey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Stripe
 
+## Unreleased
+
+- Fixed a bug where an error was thrown on the Entry edit page when Stripe was installed, but not configured with an API key yet. ([#66](https://github.com/craftcms/stripe/pull/66))
+- Fixed a bug where “Stripe Sync All” utility was showing when Stripe was installed, but not configured with an API key yet. ([#66](https://github.com/craftcms/stripe/pull/66))
+
 ## 1.3.1 - 2024-11-28
 
 - Fixed a bug where the Products index page listed “Link” as a sort option.. ([#59](https://github.com/craftcms/stripe/issues/59))

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -329,13 +329,15 @@ class Plugin extends BasePlugin
      */
     private function registerUtilityTypes(): void
     {
-        Event::on(
-            Utilities::class,
-            Utilities::EVENT_REGISTER_UTILITIES,
-            function(RegisterComponentTypesEvent $event) {
-                $event->types[] = Sync::class;
-            }
-        );
+        if (!empty(Plugin::getInstance()->getApi()->getApiKey())) {
+            Event::on(
+                Utilities::class,
+                Utilities::EVENT_REGISTER_UTILITIES,
+                function(RegisterComponentTypesEvent $event) {
+                    $event->types[] = Sync::class;
+                }
+            );
+        }
     }
 
     /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -572,27 +572,32 @@ class Plugin extends BasePlugin
 
     private function registerUserActions(): void
     {
-        Event::on(
-            User::class,
-            Element::EVENT_DEFINE_ACTION_MENU_ITEMS,
-            function(DefineMenuItemsEvent $event) {
-                $sender = $event->sender;
-                if ($email = $sender->email && Craft::$app->getUser()->checkPermission('accessPlugin-stripe')) {
-                    $customers = Plugin::getInstance()->getApi()->fetchAllCustomers(['email' => $email]);
-                    if ($customers) {
-                        $stripeIds = collect($customers)->pluck('id');
-                        $event->items[] = [
-                            'action' => 'stripe/sync/customer',
-                            'type' => MenuItemType::Button,
-                            'params' => [
-                                'stripeIds' => $stripeIds->toArray(),
-                            ],
-                            'label' => Craft::t('stripe', 'Sync from Stripe'),
-                        ];
+        if (
+            !empty(Plugin::getInstance()->getApi()->getApiKey()) &&
+            Craft::$app->getUser()->checkPermission('accessPlugin-stripe')
+        ) {
+            Event::on(
+                User::class,
+                Element::EVENT_DEFINE_ACTION_MENU_ITEMS,
+                function(DefineMenuItemsEvent $event) {
+                    $sender = $event->sender;
+                    if ($email = $sender->email) {
+                        $customers = Plugin::getInstance()->getApi()->fetchAllCustomers(['email' => $email]);
+                        if ($customers) {
+                            $stripeIds = collect($customers)->pluck('id');
+                            $event->items[] = [
+                                'action' => 'stripe/sync/customer',
+                                'type' => MenuItemType::Button,
+                                'params' => [
+                                    'stripeIds' => $stripeIds->toArray(),
+                                ],
+                                'label' => Craft::t('stripe', 'Sync from Stripe'),
+                            ];
+                        }
                     }
                 }
-            }
-        );
+            );
+        }
     }
 
     /**

--- a/src/controllers/WebhooksController.php
+++ b/src/controllers/WebhooksController.php
@@ -101,7 +101,7 @@ class WebhooksController extends Controller
         $pluginSettings = $plugin->getSettings();
 
         if (!$pluginSettings->secretKey) {
-            throw new ServerErrorHttpException('No Stripe API key found. Make sure you have added one in the plugin’s settings screen.');
+            return $this->renderTemplate('stripe/webhooks/_index', ['notConfigured' => true]);
         }
 
         $webhookRecord = $plugin->getWebhooks()->getWebhookRecord();

--- a/src/templates/webhooks/_index.twig
+++ b/src/templates/webhooks/_index.twig
@@ -4,6 +4,7 @@
 {% set selectedSubnavItem = 'stripeWebhooks' %}
 
 {% set title = "Webhooks"|t('stripe') %}
+{% set notConfigured = notConfigured ?? false %}
 
 {% set navItems = {} %}
 
@@ -11,48 +12,52 @@
 
     <h2>{{ "Webhook Management"|t('stripe') }}</h2>
 
-    {% if not hasWebhook %}
-        <p>{{ "Create the webhook for the current environment."|t('stripe') }} <a class="go" href="https://github.com/craftcms/stripe#webhooks">{{ 'Learn more'|t('app') }}</a></p>
-    {% endif %}
+    {% if notConfigured %}
+        <p>{{ "No Stripe API key found. Make sure you have added one in the plugin’s settings screen."|t('stripe') }}
 
-    {# Divs needed for the Admin Table js below #}
-    <div class="pane tablepane hairline">
-        <div id="webhooks-container">
+    {% else %}
+        {% if not hasWebhook %}
+            <p>{{ "Create the webhook for the current environment."|t('stripe') }} <a class="go" href="https://github.com/craftcms/stripe#webhooks">{{ 'Learn more'|t('app') }}</a></p>
+        {% endif %}
+
+        {# Divs needed for the Admin Table js below #}
+        <div class="pane tablepane hairline">
+            <div id="webhooks-container">
+            </div>
         </div>
-    </div>
 
-    {% if not hasWebhook %}
-        <form method="POST">
-            {{ actionInput('stripe/webhooks/create') }}
-            {{ redirectInput('stripe/webhooks') }}
-            {{ csrfInput() }}
-            <button class="btn primary" type="submit">{{ "Create"|t('stripe') }}</button>
-        </form>
-    {% endif %}
+        {% if not hasWebhook %}
+            <form method="POST">
+                {{ actionInput('stripe/webhooks/create') }}
+                {{ redirectInput('stripe/webhooks') }}
+                {{ csrfInput() }}
+                <button class="btn primary" type="submit">{{ "Create"|t('stripe') }}</button>
+            </form>
+        {% endif %}
 
-    {% set tableData = [] %}
+        {% set tableData = [] %}
 
-    {% if webhookInfo is not empty %}
-        {% set tableData = [{
-            id: recordId,
-            title: webhookInfo.description ?? webhookInfo.id,
-            apiVersion: webhookInfo.api_version,
-            livemode: webhookInfo.livemode,
-            whStatus: webhookInfo.status,
-            address: webhookInfo.url,
-        }] %}
-    {% endif %}
+        {% if webhookInfo is not empty %}
+            {% set tableData = [{
+                id: recordId,
+                title: webhookInfo.description ?? webhookInfo.id,
+                apiVersion: webhookInfo.api_version,
+                livemode: webhookInfo.livemode,
+                whStatus: webhookInfo.status,
+                address: webhookInfo.url,
+            }] %}
+        {% endif %}
 
-    {% js %}
-        var columns = [
+        {% js %}
+            var columns = [
             { name: '__slot:title', title: '{{ 'Topic'|t('stripe') }}' },
             { name: 'apiVersion', title: '{{ 'API Version'|t('stripe') }}' },
             { name: 'livemode', title: '{{ 'Live Mode'|t('stripe') }}' },
             { name: 'whStatus', title: '{{ 'Status'|t('stripe') }}' },
             { name: 'address', title: '{{ 'URL'|t('stripe') }}' },
-        ];
+            ];
 
-        new Craft.VueAdminTable({
+            new Craft.VueAdminTable({
             fullPane: false,
             columns: columns,
             container: '#webhooks-container',
@@ -63,40 +68,41 @@
             emptyMessage: Craft.t('stripe', 'No webhooks exist yet.'),
             tableData: {{ tableData|json_encode|raw }},
             deleteCallback: function() {
-                window.location.reload(); // We need to reload to get the create button showing again
+            window.location.reload(); // We need to reload to get the create button showing again
             },
-        });
-    {% endjs %}
+            });
+        {% endjs %}
 
-    <hr />
+        <hr />
 
-    <h2>{{ "Webhook Settings"|t('stripe') }}</h2>
-    <form method="POST">
-        {{ actionInput('stripe/webhooks/save-settings') }}
-        {{ redirectInput('stripe/webhooks') }}
-        {{ csrfInput() }}
+        <h2>{{ "Webhook Settings"|t('stripe') }}</h2>
+        <form method="POST">
+            {{ actionInput('stripe/webhooks/save-settings') }}
+            {{ redirectInput('stripe/webhooks') }}
+            {{ csrfInput() }}
 
-        {{ forms.autosuggestField({
-            first: true,
-            label: 'Webhook Signing Secret'|t('stripe'),
-            id: 'webhookSigningSecret',
-            name: 'webhookSigningSecret',
-            value: webhookSigningSecret,
-            suggestEnvVars: true,
-            autofocus: true,
-        }) }}
+            {{ forms.autosuggestField({
+                first: true,
+                label: 'Webhook Signing Secret'|t('stripe'),
+                id: 'webhookSigningSecret',
+                name: 'webhookSigningSecret',
+                value: webhookSigningSecret,
+                suggestEnvVars: true,
+                autofocus: true,
+            }) }}
 
-        {{ forms.autosuggestField({
-            first: true,
-            label: 'Webhook ID'|t('stripe'),
-            id: 'webhookId',
-            name: 'webhookId',
-            value: webhookId,
-            suggestEnvVars: true,
-            autofocus: true,
-        }) }}
+            {{ forms.autosuggestField({
+                first: true,
+                label: 'Webhook ID'|t('stripe'),
+                id: 'webhookId',
+                name: 'webhookId',
+                value: webhookId,
+                suggestEnvVars: true,
+                autofocus: true,
+            }) }}
 
-        <button class="btn primary" type="submit">{{ "Save"|t('app') }}</button>
-    </form>
+            <button class="btn primary" type="submit">{{ "Save"|t('app') }}</button>
+        </form>
+    {% endif %}
 {% endblock %}
 

--- a/src/templates/webhooks/_index.twig
+++ b/src/templates/webhooks/_index.twig
@@ -13,7 +13,7 @@
     <h2>{{ "Webhook Management"|t('stripe') }}</h2>
 
     {% if notConfigured %}
-        <p>{{ "No Stripe API key found. Make sure you have added one in the plugin’s settings screen."|t('stripe') }}
+        <p>{{ "No Stripe API key found. Make sure you have added one in the plugin’s settings screen."|t('stripe') }}</p>
 
     {% else %}
         {% if not hasWebhook %}

--- a/src/translations/en/stripe.php
+++ b/src/translations/en/stripe.php
@@ -62,6 +62,7 @@ return [
     'No invoices exist yet.' => 'No invoices exist yet.',
     'No payment methods exist yet.' => 'No payment methods exist yet.',
     'No webhooks exist yet.' => 'No webhooks exist yet.',
+    'No Stripe API key found. Make sure you have added one in the plugin’s settings screen.' => 'No Stripe API key found. Make sure you have added one in the plugin’s settings screen.',
     'No' => 'No',
     'One-time' => 'One-time',
     'Open in Stripe' => 'Open in Stripe',


### PR DESCRIPTION
### Description
Check if the `apiKey` is provided before:
- adding a user action menu (Sync from Stripe)
- showing the sync utility (Stripe Sync All)

If the `apiKey` is missing, show a message instead of throwing an error on the Stripe > Webhooks page.


### Related issues
n/a
