### PR TITLE
`createUserIfMissing` should only be available for cms pro and up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Stripe
 
+## Unreleased
+
+- Fixed a bug where the plugin was attempting to create missing users when `createUserIfMissing` was `true` but the Craft edition didn’t allow for multiple users. ([#72](https://github.com/craftcms/stripe/pull/72))
+
 ## 1.3.2 - 2024-12-11
 
 - Fixed an error that occurred on Edit Entry screens if Stripe wasn’t configured with an API key. ([#66](https://github.com/craftcms/stripe/pull/66))

--- a/src/services/Subscriptions.php
+++ b/src/services/Subscriptions.php
@@ -9,6 +9,7 @@ namespace craft\stripe\services;
 
 use Craft;
 use craft\elements\User;
+use craft\enums\CmsEdition;
 use craft\events\ConfigEvent;
 use craft\helpers\Json;
 use craft\helpers\ProjectConfig;
@@ -154,7 +155,7 @@ class Subscriptions extends Component
         }
 
         $settings = Plugin::getInstance()->getSettings();
-        if ($settings->createUserIfMissing) {
+        if ($settings->createUserIfMissing && Craft::$app->edition >= CmsEdition::Pro) {
             $this->ensureUser($subscription, $subscriptionElement);
         }
 

--- a/src/services/Subscriptions.php
+++ b/src/services/Subscriptions.php
@@ -155,7 +155,7 @@ class Subscriptions extends Component
         }
 
         $settings = Plugin::getInstance()->getSettings();
-        if ($settings->createUserIfMissing && Craft::$app->edition >= CmsEdition::Pro) {
+        if ($settings->createUserIfMissing && Craft::$app->edition->value >= CmsEdition::Pro->value) {
             $this->ensureUser($subscription, $subscriptionElement);
         }
 


### PR DESCRIPTION
### Description
`createUserIfMissing` setting should only be enforced if we are allowed to create multiple users. This PR ensures that the setting is only respected if you’re using at least Craft CMS Pro.


### Related issues
https://github.com/craftcms/stripe/pull/57
