### PR TITLE
use old email to search for stripe customers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes for Stripe
 
 ## Unreleased
+
 - Fixed a bug where Craft user’s email address was not synced to Stripe even if `syncChangedUserEmailsToStripe` was set to `true`. ([#69](https://github.com/craftcms/stripe/issues/69))
 
 ## 1.3.2 - 2024-12-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes for Stripe
 
+## Unreleased
+- Fixed a bug where Craft user’s email address was not synced to Stripe even if `syncChangedUserEmailsToStripe` was set to `true`. ([#69](https://github.com/craftcms/stripe/issues/69))
+
 ## 1.3.2 - 2024-12-11
 
 - Fixed an error that occurred on Edit Entry screens if Stripe wasn’t configured with an API key. ([#66](https://github.com/craftcms/stripe/pull/66))

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -619,7 +619,9 @@ class Plugin extends BasePlugin
                 $oldEmail = $userRecord->getAttribute('email');
                 $newEmail = $user->email;
                 if ($oldEmail && $newEmail && ($oldEmail != $newEmail)) {
+                    $user->email = $oldEmail;
                     $customers = $user->getStripeCustomers();
+                    $user->email = $newEmail;
                     if ($customers->isNotEmpty()) {
                         $client = $this->getApi()->getClient();
                         foreach ($customers->all() as $customer) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -619,12 +619,10 @@ class Plugin extends BasePlugin
                 $oldEmail = $userRecord->getAttribute('email');
                 $newEmail = $user->email;
                 if ($oldEmail && $newEmail && ($oldEmail != $newEmail)) {
-                    $user->email = $oldEmail;
-                    $customers = $user->getStripeCustomers();
-                    $user->email = $newEmail;
-                    if ($customers->isNotEmpty()) {
+                    $customers = Plugin::getInstance()->getCustomers()->getCustomersByEmail($oldEmail);
+                    if (!empty($customers)) {
                         $client = $this->getApi()->getClient();
-                        foreach ($customers->all() as $customer) {
+                        foreach ($customers as $customer) {
                             try {
                                 $updatedCustomer = $client->customers->update($customer->stripeId, ['email' => $newEmail]);
                                 $this->getCustomers()->createOrUpdateCustomer($updatedCustomer);


### PR DESCRIPTION
### Description
When changing a credentialed user’s email address and `syncChangedUserEmailsToStripe` is `true`, we need to use the email address from before the change to search for the Stripe customers that should get updated.


### Related issues
#69 
