### PR TITLE
move key and permission checks inside the event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes for Stripe
 
+## Unreleased
+- Fixed an error where the plugin could attempt to check User permissions before Craft was fully initialized. ([#71](https://github.com/craftcms/stripe/issues/71)) 
+
 ## 1.3.2 - 2024-12-11
 
 - Fixed an error that occurred on Edit Entry screens if Stripe wasn’t configured with an API key. ([#66](https://github.com/craftcms/stripe/pull/66))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release Notes for Stripe
 
 ## Unreleased
-- Fixed an error where the plugin could attempt to check User permissions before Craft was fully initialized. ([#71](https://github.com/craftcms/stripe/issues/71)) 
+
+- Fixed an error where the plugin could attempt to check User permissions before Craft was fully initialized. ([#71](https://github.com/craftcms/stripe/issues/71))
 
 ## 1.3.2 - 2024-12-11
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -574,14 +574,14 @@ class Plugin extends BasePlugin
 
     private function registerUserActions(): void
     {
-        if (
-            !empty(Plugin::getInstance()->getApi()->getApiKey()) &&
-            Craft::$app->getUser()->checkPermission('accessPlugin-stripe')
-        ) {
-            Event::on(
-                User::class,
-                Element::EVENT_DEFINE_ACTION_MENU_ITEMS,
-                function(DefineMenuItemsEvent $event) {
+        Event::on(
+            User::class,
+            Element::EVENT_DEFINE_ACTION_MENU_ITEMS,
+            function(DefineMenuItemsEvent $event) {
+                if (
+                    !empty(Plugin::getInstance()->getApi()->getApiKey()) &&
+                    Craft::$app->getUser()->checkPermission('accessPlugin-stripe')
+                ) {
                     $sender = $event->sender;
                     if ($email = $sender->email) {
                         $customers = Plugin::getInstance()->getApi()->fetchAllCustomers(['email' => $email]);
@@ -598,8 +598,8 @@ class Plugin extends BasePlugin
                         }
                     }
                 }
-            );
-        }
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
### Description
Move key and permission checks inside the event to avoid query being initiated before Craft is fully initialised.


### Related issues

#71 