### PR TITLE
Parse date apram instead of timesteamp param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Stripe
 
+## Unreleased
+
+- Clarified that timestamps must be passed into `nextPaymentDate` queries. ([#83](https://github.com/craftcms/stripe/pull/83))
+
 ## 1.4.0 - 2025-02-18
 
 - Stripe now requires Craft CMS 5.6+.

--- a/src/elements/db/SubscriptionQuery.php
+++ b/src/elements/db/SubscriptionQuery.php
@@ -909,7 +909,7 @@ class SubscriptionQuery extends ElementQuery
         }
 
         if (isset($this->nextPaymentDate)) {
-            $this->subQuery->andWhere(Db::parseTimestampParam(
+            $this->subQuery->andWhere(Db::parseDateParam(
                 "stripe_subscriptiondata.currentPeriodEnd",
                 $this->nextPaymentDate,
             ));

--- a/src/elements/db/SubscriptionQuery.php
+++ b/src/elements/db/SubscriptionQuery.php
@@ -602,7 +602,7 @@ class SubscriptionQuery extends ElementQuery
      *
      * ```twig
      * {# Fetch {elements} with a payment due soon #}
-     * {% set aWeekFromNow = date('+7 days')|format('u') %}
+     * {% set aWeekFromNow = date('+7 days')|date('U') %}
      *
      * {% set {elements-var} = {twig-method}
      *   .nextPaymentDate("< #{aWeekFromNow}")

--- a/src/elements/db/SubscriptionQuery.php
+++ b/src/elements/db/SubscriptionQuery.php
@@ -588,19 +588,21 @@ class SubscriptionQuery extends ElementQuery
     /**
      * Narrows the query results based on the subscriptions’ next payment dates.
      *
+     * Values must be a unix timestamp.
+     *
      * Possible values include:
      *
      * | Value | Fetches {elements}…
      * | - | -
-     * | `'>= 2018-04-01'` | with a next payment on or after 2018-04-01.
-     * | `'< 2018-05-01'` | with a next payment before 2018-05-01
-     * | `['and', '>= 2018-04-04', '< 2018-05-01']` | with a next payment between 2018-04-01 and 2018-05-01.
+     * | `'>= 1522558800'` | with a next payment on or after 1522558800 (2018-04-01).
+     * | `'< 1525150800'` | with a next payment before 1525150800 (2018-05-01)
+     * | `['and', '>= 1522558800', '< 1525150800']` | with a next payment between 1522558800 (2018-04-01) and 1525150800 (2018-05-01).
      *
      * ---
      *
      * ```twig
      * {# Fetch {elements} with a payment due soon #}
-     * {% set aWeekFromNow = date('+7 days')|atom %}
+     * {% set aWeekFromNow = date('+7 days')|format('u') %}
      *
      * {% set {elements-var} = {twig-method}
      *   .nextPaymentDate("< #{aWeekFromNow}")
@@ -609,7 +611,7 @@ class SubscriptionQuery extends ElementQuery
      *
      * ```php
      * // Fetch {elements} with a payment due soon
-     * $aWeekFromNow = new \DateTime('+7 days')->format(\DateTime::ATOM);
+     * $aWeekFromNow = new \DateTime('+7 days')->getTimestamp()
      *
      * ${elements-var} = {php-method}
      *     ->nextPaymentDate("< {$aWeekFromNow}")
@@ -909,7 +911,7 @@ class SubscriptionQuery extends ElementQuery
         }
 
         if (isset($this->nextPaymentDate)) {
-            $this->subQuery->andWhere(Db::parseDateParam(
+            $this->subQuery->andWhere(Db::parseTimestampParam(
                 "stripe_subscriptiondata.currentPeriodEnd",
                 $this->nextPaymentDate,
             ));


### PR DESCRIPTION
Clarifies that timestamps must be passed into `nextPaymentDate` queries