### PR TITLE
safeguard against non-existent product elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Clarified that timestamps must be passed into `nextPaymentDate` queries. ([#83](https://github.com/craftcms/stripe/pull/83))
+- Fixed an issue that could occur when editing a subscription with corresponding product element not synced into the cms. ([#86](https://github.com/craftcms/stripe/pull/86))
 - Fixed an XSS vulnerability.
 
 ## 1.4.0 - 2025-02-18

--- a/src/helpers/Subscription.php
+++ b/src/helpers/Subscription.php
@@ -116,7 +116,7 @@ class Subscription
                         }
                         break;
                     case 'products':
-                        $products = $subscription->getProducts();
+                        $products = array_filter($subscription->getProducts());
                         $html = '<ul class="elements chips">';
                         foreach ($products as $product) {
                             $html .= '<li>' . Cp::elementChipHtml($product, ['size' => Cp::CHIP_SIZE_SMALL]) . '</li>';


### PR DESCRIPTION
### Description
Safeguard against viewing a subscription edit page when the product element it’s linked to doesn’t exist in the cms.


### Related issues
n/a
