### PR TITLE
Fix issue with prices not being linked to product

### DIFF
--- a/src/elements/Price.php
+++ b/src/elements/Price.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://craftcms.com/
  * @copyright Copyright (c) Pixel & Tonic, Inc.
@@ -527,7 +528,7 @@ class Price extends Element implements NestedElementInterface
         }
 
         $record->stripeId = $this->stripeId;
-        $record->primaryOwnerId = $this->getPrimaryOwnerId();
+        $record->primaryOwnerId = $this->getPrimaryOwnerId(); // Commented out to fix the issue with the price not being linked to the product
 
         // We want to always have the same date as the element table, based on the logic for updating these in the element service i.e re-saving
         $record->dateUpdated = $this->dateUpdated;
@@ -674,6 +675,14 @@ class Price extends Element implements NestedElementInterface
         }
 
         return $this->_product;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getOwnerId(): ?int
+    {
+        return $this->primaryOwnerId;
     }
 
     /**

--- a/src/elements/Price.php
+++ b/src/elements/Price.php
@@ -528,7 +528,7 @@ class Price extends Element implements NestedElementInterface
         }
 
         $record->stripeId = $this->stripeId;
-        $record->primaryOwnerId = $this->getPrimaryOwnerId(); // Commented out to fix the issue with the price not being linked to the product
+        //$record->primaryOwnerId = $this->getPrimaryOwnerId(); // Commented out to fix the issue with the price not being linked to the product
 
         // We want to always have the same date as the element table, based on the logic for updating these in the element service i.e re-saving
         $record->dateUpdated = $this->dateUpdated;

--- a/src/services/Prices.php
+++ b/src/services/Prices.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://craftcms.com/
  * @copyright Copyright (c) Pixel & Tonic, Inc.
@@ -8,8 +9,10 @@
 namespace craft\stripe\services;
 
 use Craft;
+use craft\db\Table as CraftTable;
 use craft\events\ConfigEvent;
 use craft\helpers\ArrayHelper;
+use craft\helpers\Db;
 use craft\helpers\Json;
 use craft\helpers\ProjectConfig;
 use craft\models\FieldLayout;
@@ -21,6 +24,7 @@ use craft\stripe\Plugin;
 use craft\stripe\records\PriceData as PriceDataRecord;
 use Stripe\Price as StripePrice;
 use yii\base\Component;
+use yii\db\Query;
 
 /**
  * Prices service
@@ -166,6 +170,28 @@ class Prices extends Component
             return false;
         }
 
+        // Ensure the price is properly linked in elements_owners
+        $ownerId = $priceElement->getOwnerId();
+        if ($ownerId) {
+            $exists = (new Query())
+                ->from(CraftTable::ELEMENTS_OWNERS)
+                ->where([
+                    'elementId' => $priceElement->id,
+                    'ownerId' => $ownerId,
+                ])
+                ->exists();
+
+            if (!$exists) {
+                Db::insert(CraftTable::ELEMENTS_OWNERS, [
+                    'elementId' => $priceElement->id,
+                    'ownerId' => $ownerId,
+                    'sortOrder' => 1,
+                ]);
+            }
+        }
+
+        // Remove ownerId and primaryOwnerId from attributes before saving PriceDataRecord
+        unset($attributes['ownerId'], $attributes['primaryOwnerId']);
         $attributes['priceId'] = $priceElement->id;
 
         // Find the price data or create one


### PR DESCRIPTION
### Description

This PR fixes an issue with the `Price` element's relationship to its `Product` in the Stripe plugin. The issue occurs when creating a new price through Stripe's webhook events.

**The Problem:**
- The `PriceData` table uses a generated column `productId` that automatically extracts the value from the `data` JSON field
- The code was trying to set `primaryOwnerId` directly on the `PriceRecord` in the `afterSave` method
- This caused SQL errors: `The value specified for generated column 'productId' in table 'arepa_stripe_pricedata' is not allowed`

**The Fix:**
- Removed the line that sets `primaryOwnerId` directly on the `PriceRecord`
- The relationship between `Price` and `Product` is now properly maintained through:
  1. The `elements_owners` table (for Craft's element relationship)
  2. The `data` JSON field (for Stripe's product reference)

**Testing:**
- Tested with multiple products and prices
- Verified that prices are correctly linked to their products
- No more SQL errors when saving prices

### Related issues

Fixes #90 - SQL error when creating a new price through Stripe webhook