### PR TITLE
Safeguard for setting ownership of the price when the price is created before the product

### DIFF
--- a/src/elements/Price.php
+++ b/src/elements/Price.php
@@ -575,20 +575,15 @@ class Price extends Element implements NestedElementInterface
                     ->max('[[eo.sortOrder]]');
                 $this->sortOrder = $max ? $max + 1 : 1;
             }
-            if ($isNew) {
-                Db::insert(CraftTable::ELEMENTS_OWNERS, [
-                    'elementId' => $this->id,
-                    'ownerId' => $ownerId,
-                    'sortOrder' => $this->sortOrder,
-                ]);
-            } else {
-                Db::update(CraftTable::ELEMENTS_OWNERS, [
-                    'sortOrder' => $this->sortOrder,
-                ], [
-                    'elementId' => $this->id,
-                    'ownerId' => $ownerId,
-                ]);
-            }
+
+            Db::upsert(CraftTable::ELEMENTS_OWNERS, [
+                'elementId' => $this->id,
+                'ownerId' => $ownerId,
+                'sortOrder' => $this->sortOrder,
+            ], [
+                'elementId' => $this->id,
+                'ownerId' => $ownerId,
+            ]);
         }
 
         $this->setDirtyAttributes($dirtyAttributes);

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -556,6 +556,26 @@ class Product extends Element
         $record->save(false);
 
         parent::afterSave($isNew);
+
+        if ($isNew) {
+            // check if price was created earlier on (webhook for the price creation can come before one for the product creation)
+            // this will happen consistently if you're using e.g. the Stripe Shell/CLI to create a product with a default price
+
+            // check if we already have any prices that match this product's stripeId
+            $prices = Price::find()->stripeProductId($this->stripeId)->all();
+
+            // if we do
+            if (count($prices) > 0) {
+                foreach ($prices as $price) {
+                    // and the price doesn't have ownership data
+                    if ($price->primaryOwnerId === null) {
+                        // create the ownership relation
+                        $price->primaryOwnerId = $this->id;
+                        Craft::$app->getElements()->saveElement($price);
+                    }
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Description
In some cases, the price creation webhook can be delivered before the product creation one. When this happens, price and product elements are created, but the product doesn’t have the correct price ownership.

Solution: When a product is created, check if there are any prices that belong to its Stripe ID, and if they don’t have the ownership data, set it.


### Related issues
#90 
