### PR TITLE
Fix customer sync

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,0 +1,7 @@
+# Release Notes for Stripe
+
+- Added the `stripe/sync/customer` command.
+- Added `craft\stripe\jobs\SyncSingleCustomerData`.
+- Added `\craft\stripe\services\Invoices::syncCustomerInvoices()`.
+- Added `\craft\stripe\services\PaymentMethods::syncCustomerPaymentMethods()`.
+- Added `\craft\stripe\services\Subscriptions::syncCustomerSubscriptions()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Release Notes for Stripe
 
-## Unreleased
-
-- Added the `stripe/sync/customer` command.
-- Added `craft\stripe\jobs\SyncSingleCustomerData`.
-- Added `\craft\stripe\services\Invoices::syncCustomerInvoices()`.
-- Added `\craft\stripe\services\PaymentMethods::syncCustomerPaymentMethods()`.
-- Added `\craft\stripe\services\Subscriptions::syncCustomerSubscriptions()`.
-
 ## 1.6.0 - 2025-06-25
 
 - The “Sync from Stripe” user action now shows a confirmation dialog before syncing customer data from Stripe. ([#87](https://github.com/craftcms/stripe/pull/87))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes for Stripe
 
+## Unreleased
+
+- Added the `stripe/sync/customer` command.
+- Added `craft\stripe\jobs\SyncSingleCustomerData`.
+- Added `\craft\stripe\services\Invoices::syncCustomerInvoices()`.
+- Added `\craft\stripe\services\PaymentMethods::syncCustomerPaymentMethods()`.
+- Added `\craft\stripe\services\Subscriptions::syncCustomerSubscriptions()`.
+
 ## 1.6.0 - 2025-06-25
 
 - The “Sync from Stripe” user action now shows a confirmation dialog before syncing customer data from Stripe. ([#87](https://github.com/craftcms/stripe/pull/87))

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -30,7 +30,6 @@ use craft\feedme\events\RegisterFeedMeFieldsEvent;
 use craft\feedme\services\Fields as FeedMeFields;
 use craft\fields\Link;
 use craft\helpers\Html;
-use craft\helpers\Queue;
 use craft\helpers\UrlHelper;
 use craft\models\FieldLayout;
 use craft\records\User as UserRecord;
@@ -47,7 +46,7 @@ use craft\stripe\feedme\fields\Subscriptions as FeedMeSubscriptions;
 use craft\stripe\fieldlayoutelements\PricesField;
 use craft\stripe\fields\Products as ProductsField;
 use craft\stripe\fields\Subscriptions as SubscriptionsField;
-use craft\stripe\jobs\SyncData;
+use craft\stripe\jobs\SyncSingleCustomerData;
 use craft\stripe\linktypes\Product as ProductLinkType;
 use craft\stripe\models\Settings;
 use craft\stripe\services\Api;
@@ -164,7 +163,7 @@ class Plugin extends BasePlugin
         $this->registerConditionRules();
         $this->registerUserActions();
         $this->registerFeedMeEvents();
-        $this->handleUserElementChanges();
+        $this->registerUserElementChanges();
 
         $request = Craft::$app->getRequest();
         if (!$request->getIsConsoleRequest()) {
@@ -642,8 +641,10 @@ class Plugin extends BasePlugin
      *
      * @return void
      */
-    private function handleUserElementChanges(): void
+    private function registerUserElementChanges(): void
     {
+        $client = $this->getApi()->getClient();
+
         // if email address got changed - update stripe
         Event::on(User::class, User::EVENT_BEFORE_SAVE, function(ModelEvent $event) {
             /** @var User|StripeCustomerBehavior $user */
@@ -670,8 +671,6 @@ class Plugin extends BasePlugin
             }
         });
 
-        // if user is saved, and they have an email address and exist in stripe, but we don't have their stripe customer data
-        // kick off queue job to sync customer-related data
         Event::on(User::class, User::EVENT_AFTER_SAVE, function(ModelEvent $event) {
             /** @var User|StripeCustomerBehavior $user */
             $user = $event->sender;
@@ -686,18 +685,19 @@ class Plugin extends BasePlugin
                 return;
             }
 
-            // Search for customer in Stripe by their email address:
+            // Check Stripe for customers with this email and queue sync jobs for each
             try {
-                // If the plugin isn't configured yet, this may fail:
-                $stripe = $this->getApi()->getClient();
-                $stripeCustomers = $stripe->customers->search(['query' => "email:'{$user->email}'"]);
-
-                // If we found Stripe customers with that email address, kick off the queue job to sync data:
-                if (!$stripeCustomers->isEmpty()) {
-                    Queue::push(new SyncData());
+                $api = $this->getApi();
+                $stripeCustomers = $api->fetchAllCustomers(['email' => $user->email]);
+                
+                foreach ($stripeCustomers as $stripeCustomer) {
+                    // Queue a job to sync this customer's data
+                    Craft::$app->queue->push(new SyncSingleCustomerData([
+                        'stripeCustomerId' => $stripeCustomer->id,
+                    ]));
                 }
-            } catch (\Stripe\Exception\ExceptionInterface $e) {
-                Craft::error("Tried to synchronize user data, but the plugin was not fully configured: {$e->getMessage()}", 'stripe');
+            } catch (\Exception $e) {
+                Craft::error("Unable to fetch Stripe customers for email {$user->email}: {$e->getMessage()}", 'stripe');
             }
         });
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -30,6 +30,7 @@ use craft\feedme\events\RegisterFeedMeFieldsEvent;
 use craft\feedme\services\Fields as FeedMeFields;
 use craft\fields\Link;
 use craft\helpers\Html;
+use craft\helpers\Queue;
 use craft\helpers\UrlHelper;
 use craft\models\FieldLayout;
 use craft\records\User as UserRecord;
@@ -643,8 +644,6 @@ class Plugin extends BasePlugin
      */
     private function registerUserElementChanges(): void
     {
-        $client = $this->getApi()->getClient();
-
         // if email address got changed - update stripe
         Event::on(User::class, User::EVENT_BEFORE_SAVE, function(ModelEvent $event) {
             /** @var User|StripeCustomerBehavior $user */
@@ -692,7 +691,7 @@ class Plugin extends BasePlugin
                 
                 foreach ($stripeCustomers as $stripeCustomer) {
                     // Queue a job to sync this customer's data
-                    Craft::$app->queue->push(new SyncSingleCustomerData([
+                    Queue::push(new SyncSingleCustomerData([
                         'stripeCustomerId' => $stripeCustomer->id,
                     ]));
                 }

--- a/src/console/controllers/SyncController.php
+++ b/src/console/controllers/SyncController.php
@@ -90,6 +90,18 @@ class SyncController extends Controller
     }
 
     /**
+     * stripe/sync/customer command - Sync a single customer by Stripe ID
+     *
+     * @param string $customerId The Stripe customer ID
+     */
+    public function actionCustomer(string $customerId): int
+    {
+        $this->syncSingleCustomer($customerId);
+
+        return ExitCode::OK;
+    }
+
+    /**
      * stripe/sync/payment-methods command
      */
     public function actionPaymentMethods(): int
@@ -216,5 +228,56 @@ class SyncController extends Controller
         $time = microtime(true) - $start;
 
         $this->stdout('Finished syncing ' . $count . ' invoice(s) in ' . round($time, 2) . 's' . PHP_EOL . PHP_EOL, Console::FG_GREEN);
+    }
+
+    /**
+     * Sync a single customer and all their related data from Stripe
+     *
+     * @param string $customerId The Stripe customer ID
+     * @return void
+     * @throws \Throwable
+     * @throws \yii\base\InvalidConfigException
+     */
+    private function syncSingleCustomer(string $customerId): void
+    {
+        $this->stdout("Syncing Stripe customer {$customerId} and related data…" . PHP_EOL . PHP_EOL, Console::FG_GREEN);
+
+        $start = microtime(true);
+        
+        $plugin = Plugin::getInstance();
+        $api = $plugin->getApi();
+        
+        try {
+            // Fetch the customer from Stripe
+            $stripeCustomer = $api->fetchCustomerById($customerId);
+            
+            // Sync the customer data
+            $this->stdout('Syncing customer data…' . PHP_EOL, Console::FG_YELLOW);
+            $plugin->getCustomers()->createOrUpdateCustomer($stripeCustomer);
+            
+            // Sync customer's subscriptions
+            $this->stdout('Syncing customer subscriptions…' . PHP_EOL, Console::FG_YELLOW);
+            $subscriptionCount = $plugin->getSubscriptions()->syncCustomerSubscriptions($stripeCustomer);
+            
+            // Sync customer's invoices
+            $this->stdout('Syncing customer invoices…' . PHP_EOL, Console::FG_YELLOW);
+            $invoiceCount = $plugin->getInvoices()->syncCustomerInvoices($stripeCustomer);
+            
+            // Sync customer's payment methods
+            $this->stdout('Syncing customer payment methods…' . PHP_EOL, Console::FG_YELLOW);
+            $paymentMethodCount = $plugin->getPaymentMethods()->syncCustomerPaymentMethods($stripeCustomer);
+            
+            $time = microtime(true) - $start;
+            
+            $this->stdout(PHP_EOL . "Finished syncing customer {$customerId}:" . PHP_EOL, Console::FG_GREEN);
+            $this->stdout("  - Customer data synced" . PHP_EOL, Console::FG_GREEN);
+            $this->stdout("  - {$subscriptionCount} subscription(s) synced" . PHP_EOL, Console::FG_GREEN);
+            $this->stdout("  - {$invoiceCount} invoice(s) synced" . PHP_EOL, Console::FG_GREEN);
+            $this->stdout("  - {$paymentMethodCount} payment method(s) synced" . PHP_EOL, Console::FG_GREEN);
+            $this->stdout("  - Time: " . round($time, 2) . 's' . PHP_EOL . PHP_EOL, Console::FG_GREEN);
+        } catch (\Exception $e) {
+            $this->stderr("Error syncing customer {$customerId}: " . $e->getMessage() . PHP_EOL, Console::FG_RED);
+            throw $e;
+        }
     }
 }

--- a/src/controllers/SyncController.php
+++ b/src/controllers/SyncController.php
@@ -21,6 +21,8 @@ class SyncController extends Controller
 {
     public function actionAll(): YiiResponse
     {
+        // TODO: This will likely time out if you have a lot of data, maybe we look to move all this into the SyncData job.
+
         Plugin::getInstance()->getProducts()->syncAllProducts();
         Plugin::getInstance()->getPrices()->syncAllPrices();
         Plugin::getInstance()->getSubscriptions()->syncAllSubscriptions();
@@ -38,6 +40,8 @@ class SyncController extends Controller
      */
     public function actionCustomer(): YiiResponse
     {
+        // TODO: Look to allow this to use the new SyncSingleCustomerData job in future?
+
         $stripeIds = Craft::$app->getRequest()->getRequiredParam('stripeIds');
         foreach (explode(',', $stripeIds) as $stripeId) {
             $stripeCustomer = Plugin::getInstance()->getApi()->fetchCustomerById($stripeId);

--- a/src/jobs/SyncSingleCustomerData.php
+++ b/src/jobs/SyncSingleCustomerData.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace craft\stripe\jobs;
+
+use Craft;
+use craft\queue\BaseJob;
+use craft\stripe\Plugin;
+
+/**
+ * Sync Single Customer Data queue job
+ */
+class SyncSingleCustomerData extends BaseJob
+{
+    /**
+     * @var string The Stripe customer ID to sync
+     */
+    public string $stripeCustomerId;
+
+    /**
+     * @inheritdoc
+     */
+    public function execute($queue): void
+    {
+        $plugin = Plugin::getInstance();
+        $api = $plugin->getApi();
+
+        // Fetch the customer from Stripe
+        $stripeCustomer = $api->fetchCustomerById($this->stripeCustomerId);
+
+        // Sync the customer data
+        $plugin->getCustomers()->createOrUpdateCustomer($stripeCustomer);
+        $this->setProgress($queue, 0.25);
+
+        // Sync customer's subscriptions
+        $plugin->getSubscriptions()->syncCustomerSubscriptions($stripeCustomer);
+        $this->setProgress($queue, 0.5);
+
+        // Sync customer's invoices
+        $plugin->getInvoices()->syncCustomerInvoices($stripeCustomer);
+        $this->setProgress($queue, 0.75);
+
+        // Sync customer's payment methods
+        $plugin->getPaymentMethods()->syncCustomerPaymentMethods($stripeCustomer);
+        $this->setProgress($queue, 1);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function defaultDescription(): ?string
+    {
+        return Craft::t('stripe', 'Sync Stripe data for customer {customerId}.', [
+            'customerId' => $this->stripeCustomerId,
+        ]);
+    }
+}

--- a/src/services/Invoices.php
+++ b/src/services/Invoices.php
@@ -16,8 +16,8 @@ use craft\stripe\db\Table;
 use craft\stripe\models\Invoice;
 use craft\stripe\Plugin;
 use craft\stripe\records\InvoiceData as InvoiceDataRecord;
-use Stripe\Invoice as StripeInvoice;
 use Stripe\Customer as StripeCustomer;
+use Stripe\Invoice as StripeInvoice;
 use yii\base\Component;
 use yii\base\InvalidConfigException;
 

--- a/src/services/Invoices.php
+++ b/src/services/Invoices.php
@@ -17,6 +17,7 @@ use craft\stripe\models\Invoice;
 use craft\stripe\Plugin;
 use craft\stripe\records\InvoiceData as InvoiceDataRecord;
 use Stripe\Invoice as StripeInvoice;
+use Stripe\Customer as StripeCustomer;
 use yii\base\Component;
 use yii\base\InvalidConfigException;
 
@@ -58,6 +59,32 @@ class Invoices extends Component
     {
         $api = Plugin::getInstance()->getApi();
         $invoices = $api->fetchAllInvoices();
+
+        $count = 0;
+        foreach ($invoices as $invoice) {
+            if ($this->createOrUpdateInvoice($invoice)) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * Syncs all invoices for a specific customer from Stripe
+     *
+     * @param StripeCustomer $stripeCustomer
+     * @return int
+     * @throws \Throwable
+     * @throws \yii\base\InvalidConfigException
+     */
+    public function syncCustomerInvoices(StripeCustomer $stripeCustomer): int
+    {
+        $api = Plugin::getInstance()->getApi();
+        $invoices = $api->fetchAll('invoices', [
+            'customer' => $stripeCustomer->id,
+            'expand' => $api->prepExpandForFetchAll(Invoice::$expandParams),
+        ]);
 
         $count = 0;
         foreach ($invoices as $invoice) {

--- a/src/services/PaymentMethods.php
+++ b/src/services/PaymentMethods.php
@@ -16,6 +16,7 @@ use craft\stripe\db\Table;
 use craft\stripe\models\PaymentMethod;
 use craft\stripe\Plugin;
 use craft\stripe\records\PaymentMethodData as PaymentMethodDataRecord;
+use Stripe\Customer as StripeCustomer;
 use Stripe\PaymentMethod as StripePaymentMethod;
 use yii\base\Component;
 use yii\base\InvalidConfigException;
@@ -63,6 +64,38 @@ class PaymentMethods extends Component
         foreach ($paymentMethods as $paymentMethod) {
             if ($this->createOrUpdatePaymentMethod($paymentMethod)) {
                 $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * Syncs all payment methods for a specific customer from Stripe
+     *
+     * @param StripeCustomer $stripeCustomer
+     * @return int
+     * @throws \Throwable
+     * @throws \yii\base\InvalidConfigException
+     */
+    public function syncCustomerPaymentMethods(StripeCustomer $stripeCustomer): int
+    {
+        $count = 0;
+        
+        // get user for customer's email address
+        $user = $stripeCustomer->email ? \Craft::$app->getUsers()->getUserByUsernameOrEmail($stripeCustomer->email) : null;
+        
+        // only get payment methods if the user exists
+        if ($user) {
+            $api = Plugin::getInstance()->getApi();
+            $paymentMethods = $stripeCustomer->allPaymentMethods($stripeCustomer->id, [
+                'expand' => $api->prepExpandForFetchAll(PaymentMethod::$expandParams),
+            ]);
+            
+            foreach ($paymentMethods as $paymentMethod) {
+                if ($this->createOrUpdatePaymentMethod($paymentMethod)) {
+                    $count++;
+                }
             }
         }
 

--- a/src/services/Subscriptions.php
+++ b/src/services/Subscriptions.php
@@ -21,6 +21,7 @@ use craft\stripe\events\StripeSubscriptionSyncEvent;
 use craft\stripe\models\Customer;
 use craft\stripe\Plugin;
 use craft\stripe\records\SubscriptionData as SubscriptionDataRecord;
+use Stripe\Customer as StripeCustomer;
 use Stripe\Stripe;
 use Stripe\Subscription as StripeSubscription;
 use yii\base\Component;
@@ -111,6 +112,37 @@ class Subscriptions extends Component
         foreach ($deletableSubscriptionElements as $element) {
             Craft::$app->elements->deleteElement($element);
         }
+    }
+
+    /**
+     * Sync all subscriptions for a specific customer from Stripe
+     *
+     * @param StripeCustomer $stripeCustomer
+     * @return int
+     * @throws \Throwable
+     * @throws \yii\base\InvalidConfigException
+     */
+    public function syncCustomerSubscriptions(StripeCustomer $stripeCustomer): int
+    {
+        $api = Plugin::getInstance()->getApi();
+
+        $iterator = $api->fetchAllIterator('subscriptions', [
+            'customer' => $stripeCustomer->id,
+            'status' => 'all',
+            'expand' => $api->prepExpandForFetchAll(Subscription::$expandParams),
+        ]);
+
+        $count = 0;
+        foreach ($iterator as $batch) {
+            /** @var \Stripe\Subscription[] $batch */
+            foreach ($batch as $subscription) {
+                if ($this->createOrUpdateSubscription($subscription)) {
+                    $count++;
+                }
+            }
+        }
+
+        return $count;
     }
 
     /**
@@ -386,7 +418,7 @@ class Subscriptions extends Component
             // in this case, we want to ensure the customer data is stored in our database
             $syncCustomerData = true;
         }
-        /** @var Customer|\Stripe\Customer $customer */
+        /** @var Customer|StripeCustomer $customer */
         if ($customer->email) {
             Craft::$app->getUsers()->ensureUserByEmail($customer->email);
 


### PR DESCRIPTION
Looks like 5b8e2bec removed the customer parameter from the job, but only because syncing a single customer was not supported as intended by the SyncData job.

Syncing all data just because a single user needs syncing was killing performance due to unnecessary syncs.

### Description

- Added the `stripe/sync/customer` command.
- Added `craft\stripe\jobs\SyncSingleCustomerData`.
- Added `\craft\stripe\services\Invoices::syncCustomerInvoices()`.
- Added `\craft\stripe\services\PaymentMethods::syncCustomerPaymentMethods()`.
- Added `\craft\stripe\services\Subscriptions::syncCustomerSubscriptions()`.

