### PR TITLE
allow passing criteria to product's getPrices method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Stripe
 
+## Unreleased
+
+- `craft\stripe\elements\Product::getPrices()` now has an optional `$criteria` argument. ([#97](https://github.com/craftcms/stripe/issues/97))
+
 ## 1.6.0 - 2025-06-25
 
 - The “Sync from Stripe” user action now shows a confirmation dialog before syncing customer data from Stripe. ([#87](https://github.com/craftcms/stripe/pull/87))

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -687,9 +687,10 @@ class Product extends Element
     /**
      * Gets the product’s prices.
      *
+     * @param array $criteria
      * @return ElementCollection<Price>
      */
-    public function getPrices(): ElementCollection
+    public function getPrices(array $criteria = []): ElementCollection
     {
         if (!isset($this->_prices)) {
             if (!$this->id) {
@@ -697,8 +698,12 @@ class Product extends Element
                 return ElementCollection::make();
             }
 
+            $query = $this->createPriceQuery();
+            if (!empty($criteria)) {
+                Craft::configure($query, $criteria);
+            }
             /** @var ElementCollection<int|string, Price> $prices */
-            $prices = $this->createPriceQuery()->collect();
+            $prices = $query->collect();
             $this->_prices = $prices;
         }
 

--- a/src/elements/db/PriceQuery.php
+++ b/src/elements/db/PriceQuery.php
@@ -66,14 +66,14 @@ class PriceQuery extends ElementQuery
     public mixed $stripeProductId = null;
 
     /**
-     * @var mixed The primary owner element ID(s) that the resulting addresses must belong to.
+     * @var mixed The primary owner element ID(s) that the resulting prices must belong to.
      * @used-by primaryOwner()
      * @used-by primaryOwnerId()
      */
     public mixed $primaryOwnerId = null;
 
     /**
-     * @var mixed The owner element ID(s) that the resulting addresses must belong to.
+     * @var mixed The owner element ID(s) that the resulting prices must belong to.
      * @used-by owner()
      * @used-by ownerId()
      */


### PR DESCRIPTION
### Description
Allows passing a query criteria array to the product’s `getPrices()` method.

The `getPrices()` method returns a collection of product prices, but it’s currently not possible to customise the query used to get those prices. This means that, for example, getting all the disabled prices for the product requires additional queries. With this PR, you’ll be able to customise which prices should be returned. For example, to get only the disabled prices for a product, you’ll be able to use `product.prices({status: 'disabled'}).all()`.

### Related issues
#97
