### PR TITLE
Bugfix/96 invoice amount formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Stripe
 
+## Unreleased
+
+- Fixed a bug where the invoice amount wasn’t formatted correctly for zero-decimal currencies. ([#96](https://github.com/craftcms/stripe/issues/96))
+
 ## 1.6.0 - 2025-06-25
 
 - The “Sync from Stripe” user action now shows a confirmation dialog before syncing customer data from Stripe. ([#87](https://github.com/craftcms/stripe/pull/87))

--- a/src/services/Invoices.php
+++ b/src/services/Invoices.php
@@ -13,6 +13,7 @@ use craft\elements\User;
 use craft\errors\MutexException;
 use craft\helpers\Json;
 use craft\stripe\db\Table;
+use craft\stripe\helpers\Price;
 use craft\stripe\models\Invoice;
 use craft\stripe\Plugin;
 use craft\stripe\records\InvoiceData as InvoiceDataRecord;
@@ -198,10 +199,14 @@ class Invoices extends Component
         $formatter = Craft::$app->getFormatter();
 
         foreach ($invoices as $invoice) {
+            $amount = $invoice->data['total'];
+            if (!in_array(strtolower($invoice->data['currency']), Price::$zeroDecimalCurrencies)) {
+                $amount = $amount / 100;
+            }
             $tableData[] = [
                 'id' => $invoice->stripeId,
                 'title' => $invoice->data['number'] ?? Craft::t('stripe', 'Draft'),
-                'amount' => $formatter->asCurrency($invoice->data['total'] / 100, $invoice->data['currency']),
+                'amount' => $formatter->asCurrency($amount, $invoice->data['currency']),
                 'stripeStatus' => $invoice->data['status'],
                 'frequency' => '',
                 'customerEmail' => $invoice->data['customer_email'],


### PR DESCRIPTION
### Description
Fixes an issue where the invoice amount displayed in the Control Panel wasn't formatted correctly for the zero-decimal currencies.


### Related issues
#96 
