### PR TITLE
Fix race condition in subscription sync and add cleanup command

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,5 +1,7 @@
 # Release Notes for Stripe
 
+- Added the `stripe/data/cleanup-duplicates` command to find and remove duplicate subscription elements.
+- Fixed a bug where duplicate subscriptions could be created. ([#101](https://github.com/craftcms/stripe/pull/101))
 - Added the `stripe/sync/customer` command.
 - Added `craft\stripe\jobs\SyncSingleCustomerData`.
 - Added `\craft\stripe\services\Invoices::syncCustomerInvoices()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Stripe
 
+## Unreleased
+
+- `craft\stripe\elements\Product::getPrices()` now has an optional `$criteria` argument. ([#97](https://github.com/craftcms/stripe/issues/97))
+
 ## 1.6.0 - 2025-06-25
 
 - The “Sync from Stripe” user action now shows a confirmation dialog before syncing customer data from Stripe. ([#87](https://github.com/craftcms/stripe/pull/87))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-- Added the `stripe/data/cleanup-duplicates` command to find and remove duplicate subscription elements.
-- Fixed a bug where duplicate subscriptions could be created. ([#101](https://github.com/craftcms/stripe/pull/101))
 - `craft\stripe\elements\Product::getPrices()` now has an optional `$criteria` argument. ([#97](https://github.com/craftcms/stripe/issues/97))
 
 ## 1.6.0 - 2025-06-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Stripe
 
+## Unreleased
+
+- Added the `stripe/data/cleanup-duplicates` command to find and remove duplicate subscription elements.
+- Fixed a race condition that could still result in duplicate subscription elements being created from concurrent webhook events. ([#44](https://github.com/craftcms/stripe/issues/44))
+
 ## 1.6.0 - 2025-06-25
 
 - The “Sync from Stripe” user action now shows a confirmation dialog before syncing customer data from Stripe. ([#87](https://github.com/craftcms/stripe/pull/87))

--- a/src/console/controllers/DataController.php
+++ b/src/console/controllers/DataController.php
@@ -31,6 +31,25 @@ class DataController extends Controller
     public $defaultAction = 'reset';
 
     /**
+     * @var bool Whether to run in dry-run mode (no deletions)
+     */
+    public bool $dryRun = false;
+
+    /**
+     * @inheritdoc
+     */
+    public function options($actionID): array
+    {
+        $options = parent::options($actionID);
+
+        if ($actionID === 'cleanup-duplicates') {
+            $options[] = 'dryRun';
+        }
+
+        return $options;
+    }
+
+    /**
      * Deletes all Stripe plugin data.
      *
      * @return int
@@ -140,5 +159,180 @@ class DataController extends Controller
         }
 
         $this->stdout(' done' . PHP_EOL, Console::FG_GREEN);
+    }
+
+    /**
+     * Finds and removes duplicate subscription elements.
+     *
+     * When duplicate subscriptions exist for the same Stripe subscription ID,
+     * this command will keep the most recently updated one and delete the others.
+     * If duplicates have different custom field content, it will prompt for confirmation.
+     *
+     * @return int
+     */
+    public function actionCleanupDuplicates(): int
+    {
+        $this->stdout('Scanning for duplicate subscription elements...' . PHP_EOL . PHP_EOL);
+
+        // Find all subscriptions grouped by stripeId
+        $allSubscriptions = Subscription::find()
+            ->status(null)
+            ->orderBy(['stripeId' => SORT_ASC, 'dateUpdated' => SORT_DESC])
+            ->all();
+
+        // Group by stripeId
+        $groupedByStripeId = [];
+        foreach ($allSubscriptions as $subscription) {
+            if ($subscription->stripeId === null) {
+                continue;
+            }
+            $groupedByStripeId[$subscription->stripeId][] = $subscription;
+        }
+
+        // Filter to only duplicates
+        $duplicateGroups = array_filter($groupedByStripeId, fn($group) => count($group) > 1);
+
+        if (empty($duplicateGroups)) {
+            $this->stdout('No duplicate subscriptions found.' . PHP_EOL, Console::FG_GREEN);
+            return ExitCode::OK;
+        }
+
+        $this->stdout('Found ' . count($duplicateGroups) . ' Stripe subscription(s) with duplicate elements.' . PHP_EOL . PHP_EOL);
+
+        $totalDeleted = 0;
+        $elementsService = Craft::$app->getElements();
+
+        foreach ($duplicateGroups as $stripeId => $subscriptions) {
+            $this->stdout("Stripe ID: $stripeId (" . count($subscriptions) . " elements)" . PHP_EOL, Console::FG_YELLOW);
+
+            // The first one is the most recently updated (due to ordering)
+            $keeper = array_shift($subscriptions);
+            $toDelete = $subscriptions;
+
+            // Check if custom field content differs
+            $keeperFieldValues = $this->getCustomFieldValues($keeper);
+
+            $hasDifferentContent = false;
+            foreach ($toDelete as $duplicate) {
+                $duplicateFieldValues = $this->getCustomFieldValues($duplicate);
+                if ($keeperFieldValues !== $duplicateFieldValues) {
+                    $hasDifferentContent = true;
+                    break;
+                }
+            }
+
+            if ($hasDifferentContent) {
+                $this->stdout('  Duplicates have different custom field content!' . PHP_EOL, Console::FG_RED);
+                $this->stdout(PHP_EOL);
+
+                // Display options
+                $options = [];
+                $allElements = array_merge([$keeper], $toDelete);
+                foreach ($allElements as $index => $sub) {
+                    $fieldValues = $this->getCustomFieldValues($sub);
+                    $fieldDisplay = empty($fieldValues) ? '(no custom fields)' : json_encode($fieldValues, JSON_UNESCAPED_SLASHES);
+                    $options[$index] = sprintf(
+                        'ID: %d | Updated: %s | Fields: %s',
+                        $sub->id,
+                        $sub->dateUpdated->format('Y-m-d H:i:s'),
+                        $fieldDisplay
+                    );
+                    $this->stdout("  [$index] {$options[$index]}" . PHP_EOL);
+                }
+                $this->stdout(PHP_EOL);
+
+                if ($this->dryRun) {
+                    $this->stdout('  [DRY RUN] Would prompt for which element to keep.' . PHP_EOL, Console::FG_CYAN);
+                    continue;
+                }
+
+                $choice = $this->select('Which element should be kept?', $options);
+
+                // Rebuild keeper and toDelete based on choice
+                $keeper = $allElements[$choice];
+                $toDelete = array_filter($allElements, fn($_, $idx) => $idx !== (int)$choice, ARRAY_FILTER_USE_BOTH);
+            } else {
+                $this->stdout(sprintf(
+                    '  Keeping: ID %d (updated: %s)' . PHP_EOL,
+                    $keeper->id,
+                    $keeper->dateUpdated->format('Y-m-d H:i:s')
+                ));
+            }
+
+            // Delete duplicates
+            foreach ($toDelete as $duplicate) {
+                $this->stdout(sprintf(
+                    '  Deleting: ID %d (updated: %s)' . PHP_EOL,
+                    $duplicate->id,
+                    $duplicate->dateUpdated->format('Y-m-d H:i:s')
+                ), Console::FG_RED);
+
+                if (!$this->dryRun) {
+                    $elementsService->deleteElement($duplicate, true);
+                }
+                $totalDeleted++;
+            }
+
+            $this->stdout(PHP_EOL);
+        }
+
+        if ($this->dryRun) {
+            $this->stdout("[DRY RUN] Would have deleted $totalDeleted duplicate element(s)." . PHP_EOL, Console::FG_CYAN);
+        } else {
+            $this->stdout("Deleted $totalDeleted duplicate element(s)." . PHP_EOL, Console::FG_GREEN);
+        }
+
+        return ExitCode::OK;
+    }
+
+    /**
+     * Get custom field values for a subscription element.
+     *
+     * @param Subscription $subscription
+     * @return array
+     */
+    private function getCustomFieldValues(Subscription $subscription): array
+    {
+        $fieldLayout = $subscription->getFieldLayout();
+        if ($fieldLayout === null) {
+            return [];
+        }
+
+        $values = [];
+        foreach ($fieldLayout->getCustomFields() as $field) {
+            $value = $subscription->getFieldValue($field->handle);
+            // Normalize the value for comparison
+            if ($value !== null) {
+                $values[$field->handle] = $this->normalizeFieldValue($value);
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * Normalize a field value for comparison.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    private function normalizeFieldValue(mixed $value): mixed
+    {
+        if (is_object($value)) {
+            if (method_exists($value, 'ids')) {
+                // Element queries - get IDs
+                return $value->ids();
+            }
+            if (method_exists($value, '__toString')) {
+                return (string)$value;
+            }
+            return serialize($value);
+        }
+
+        if (is_array($value)) {
+            return array_map(fn($v) => $this->normalizeFieldValue($v), $value);
+        }
+
+        return $value;
     }
 }

--- a/src/console/controllers/DataController.php
+++ b/src/console/controllers/DataController.php
@@ -210,11 +210,11 @@ class DataController extends Controller
             $toDelete = $subscriptions;
 
             // Check if custom field content differs
-            $keeperFieldValues = $this->getCustomFieldValues($keeper);
+            $keeperFieldValues = $keeper->getSerializedFieldValues();
 
             $hasDifferentContent = false;
             foreach ($toDelete as $duplicate) {
-                $duplicateFieldValues = $this->getCustomFieldValues($duplicate);
+                $duplicateFieldValues = $duplicate->getSerializedFieldValues();
                 if ($keeperFieldValues !== $duplicateFieldValues) {
                     $hasDifferentContent = true;
                     break;
@@ -229,7 +229,7 @@ class DataController extends Controller
                 $options = [];
                 $allElements = array_merge([$keeper], $toDelete);
                 foreach ($allElements as $index => $sub) {
-                    $fieldValues = $this->getCustomFieldValues($sub);
+                    $fieldValues = $sub->getSerializedFieldValues();
                     $fieldDisplay = empty($fieldValues) ? '(no custom fields)' : json_encode($fieldValues, JSON_UNESCAPED_SLASHES);
                     $options[$index] = sprintf(
                         'ID: %d | Updated: %s | Fields: %s',
@@ -283,56 +283,5 @@ class DataController extends Controller
         }
 
         return ExitCode::OK;
-    }
-
-    /**
-     * Get custom field values for a subscription element.
-     *
-     * @param Subscription $subscription
-     * @return array
-     */
-    private function getCustomFieldValues(Subscription $subscription): array
-    {
-        $fieldLayout = $subscription->getFieldLayout();
-        if ($fieldLayout === null) {
-            return [];
-        }
-
-        $values = [];
-        foreach ($fieldLayout->getCustomFields() as $field) {
-            $value = $subscription->getFieldValue($field->handle);
-            // Normalize the value for comparison
-            if ($value !== null) {
-                $values[$field->handle] = $this->normalizeFieldValue($value);
-            }
-        }
-
-        return $values;
-    }
-
-    /**
-     * Normalize a field value for comparison.
-     *
-     * @param mixed $value
-     * @return mixed
-     */
-    private function normalizeFieldValue(mixed $value): mixed
-    {
-        if (is_object($value)) {
-            if (method_exists($value, 'ids')) {
-                // Element queries - get IDs
-                return $value->ids();
-            }
-            if (method_exists($value, '__toString')) {
-                return (string)$value;
-            }
-            return serialize($value);
-        }
-
-        if (is_array($value)) {
-            return array_map(fn($v) => $this->normalizeFieldValue($v), $value);
-        }
-
-        return $value;
     }
 }

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -687,9 +687,10 @@ class Product extends Element
     /**
      * Gets the product’s prices.
      *
+     * @param array $criteria
      * @return ElementCollection<Price>
      */
-    public function getPrices(): ElementCollection
+    public function getPrices(array $criteria = []): ElementCollection
     {
         if (!isset($this->_prices)) {
             if (!$this->id) {
@@ -697,8 +698,12 @@ class Product extends Element
                 return ElementCollection::make();
             }
 
+            $query = $this->createPriceQuery();
+            if (!empty($criteria)) {
+                Craft::configure($query, $criteria);
+            }
             /** @var ElementCollection<int|string, Price> $prices */
-            $prices = $this->createPriceQuery()->collect();
+            $prices = $query->collect();
             $this->_prices = $prices;
         }
 

--- a/src/elements/db/PriceQuery.php
+++ b/src/elements/db/PriceQuery.php
@@ -66,14 +66,14 @@ class PriceQuery extends ElementQuery
     public mixed $stripeProductId = null;
 
     /**
-     * @var mixed The primary owner element ID(s) that the resulting addresses must belong to.
+     * @var mixed The primary owner element ID(s) that the resulting prices must belong to.
      * @used-by primaryOwner()
      * @used-by primaryOwnerId()
      */
     public mixed $primaryOwnerId = null;
 
     /**
-     * @var mixed The owner element ID(s) that the resulting addresses must belong to.
+     * @var mixed The owner element ID(s) that the resulting prices must belong to.
      * @used-by owner()
      * @used-by ownerId()
      */

--- a/src/services/Subscriptions.php
+++ b/src/services/Subscriptions.php
@@ -121,14 +121,26 @@ class Subscriptions extends Component
      */
     public function createOrUpdateSubscription(StripeSubscription $subscription): bool
     {
-        // Find the subscription element or create one
-        /** @var SubscriptionElement|null $subscriptionElement */
-        $subscriptionElement = SubscriptionElement::find()
-            ->stripeId($subscription->id)
-            ->status(null)
-            ->one() ?? new SubscriptionElement();
+        // Acquire lock before lookup to prevent race conditions where two webhooks
+        // both find no existing element and create duplicates
+        $lockKey = "stripe-subscription:$subscription->id";
+        $mutex = Craft::$app->getMutex();
+        if (!$mutex->acquire($lockKey, 15)) {
+            throw new MutexException($lockKey, 'Could not acquire a lock to create or update subscription.');
+        }
 
-        return $this->createOrUpdateSubscriptionElement($subscription, $subscriptionElement);
+        try {
+            // Find the subscription element or create one (now safely inside the lock)
+            /** @var SubscriptionElement|null $subscriptionElement */
+            $subscriptionElement = SubscriptionElement::find()
+                ->stripeId($subscription->id)
+                ->status(null)
+                ->one() ?? new SubscriptionElement();
+
+            return $this->createOrUpdateSubscriptionElement($subscription, $subscriptionElement, false);
+        } finally {
+            $mutex->release($lockKey);
+        }
     }
 
     /**
@@ -136,15 +148,16 @@ class Subscriptions extends Component
      *
      * @param StripeSubscription $subscription
      * @param SubscriptionElement $subscriptionElement
+     * @param bool $acquireLock Whether to acquire a mutex lock (set to false if caller already holds the lock)
      * @return bool Whether the synchronization succeeded.
      * @since 1.2
      */
-    public function createOrUpdateSubscriptionElement(StripeSubscription $subscription, SubscriptionElement $subscriptionElement): bool
+    public function createOrUpdateSubscriptionElement(StripeSubscription $subscription, SubscriptionElement $subscriptionElement, bool $acquireLock = true): bool
     {
         // Duplicates seem to be possible: https://github.com/craftcms/stripe/issues/44
         $lockKey = "stripe-subscription:$subscription->id";
         $mutex = Craft::$app->getMutex();
-        if (!$mutex->acquire($lockKey, 15)) {
+        if ($acquireLock && !$mutex->acquire($lockKey, 15)) {
             throw new MutexException($lockKey, 'Could not acquire a lock to create or update subscription.');
         }
 
@@ -168,7 +181,9 @@ class Subscriptions extends Component
 
         if (!$event->isValid) {
             Craft::warning("Synchronization of Stripe subscription ID #{$subscription->id} was stopped by a plugin.", 'stripe');
-            $mutex->release($lockKey);
+            if ($acquireLock) {
+                $mutex->release($lockKey);
+            }
 
             return false;
         }
@@ -178,14 +193,18 @@ class Subscriptions extends Component
                 $subscriptionElement = Craft::$app->getDrafts()->applyDraft($subscriptionElement);
             } catch (\Exception $e) {
                 Craft::error("Failed to synchronize Stripe subscription ID #{$subscription->id}. {$e->getMessage()}", 'stripe');
-                $mutex->release($lockKey);
+                if ($acquireLock) {
+                    $mutex->release($lockKey);
+                }
 
                 return false;
             }
         } else {
             if (!Craft::$app->getElements()->saveElement($subscriptionElement)) {
                 Craft::error("Failed to synchronize Stripe subscription ID #{$subscription->id}.", 'stripe');
-                $mutex->release($lockKey);
+                if ($acquireLock) {
+                    $mutex->release($lockKey);
+                }
 
                 return false;
             }
@@ -205,7 +224,9 @@ class Subscriptions extends Component
 
         $result = $subscriptionDataRecord->save();
 
-        $mutex->release($lockKey);
+        if ($acquireLock) {
+            $mutex->release($lockKey);
+        }
 
         if ($this->hasEventHandlers(self::EVENT_AFTER_SYNCHRONIZE_SUBSCRIPTION)) {
             $event = new StripeSubscriptionSyncEvent([


### PR DESCRIPTION

Moves the mutex lock acquisition before the element lookup in createOrUpdateSubscription() to prevent race conditions where concurrent webhooks both find no existing element and create duplicates

Add stripe/data/cleanup-duplicates command to find and remove duplicate subscription elements, with an interactive prompt when custom field content differs

### Related issues

#44 