### PR TITLE
Fix Sripe deeplinks

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,5 +1,6 @@
 # Release Notes for Stripe
 
+- Links to the Stripe dashboard now deep-link correctly for all account types. ([#100](https://github.com/craftcms/stripe/issues/100))
 - Added the `stripe/data/cleanup-duplicates` command to find and remove duplicate subscription elements.
 - Fixed a bug where duplicate subscriptions could be created. ([#101](https://github.com/craftcms/stripe/pull/101))
 - Added the `stripe/sync/customer` command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - `craft\stripe\elements\Product::getPrices()` now has an optional `$criteria` argument. ([#97](https://github.com/craftcms/stripe/issues/97))
+- Fixed a bug where Stripe dashboard links didn't deep-link correctly for some accounts. ([#100](https://github.com/craftcms/stripe/issues/100))
 
 ## 1.6.0 - 2025-06-25
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -769,7 +769,7 @@ class Plugin extends BasePlugin
         $secretKey = $this->getApi()->getApiKey();
 
         if (!str_starts_with($secretKey, 'sk_test_')) {
-            return 'live';
+            return '';
         }
 
         return 'test';

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -194,7 +194,25 @@ class Plugin extends BasePlugin
 
         // get stripe environment from the secret key
         $this->stripeMode = $this->getStripeMode();
-        $this->stripeBaseUrl = "$this->dashboardUrl/$this->stripeMode";
+        $this->stripeBaseUrl = $this->buildStripeBaseUrl();
+    }
+
+    /**
+     * Build the Stripe dashboard base URL with account ID for proper deep linking.
+     *
+     * @return string
+     */
+    private function buildStripeBaseUrl(): string
+    {
+        $accountId = $this->getApi()->getAccountId();
+
+        if ($accountId) {
+            // Format: https://dashboard.stripe.com/{account_id}/{mode}
+            return "$this->dashboardUrl/$accountId/$this->stripeMode";
+        }
+
+        // Fallback without account ID (will redirect via Stripe)
+        return "$this->dashboardUrl/$this->stripeMode";
     }
 
     /**

--- a/src/services/Api.php
+++ b/src/services/Api.php
@@ -317,6 +317,33 @@ class Api extends Component
     }
 
     /**
+     * Get the Stripe account ID for the current API key.
+     * The result is cached for 24 hours.
+     *
+     * @return string|null
+     */
+    public function getAccountId(): ?string
+    {
+        $apiKey = $this->getApiKey();
+        if (!$apiKey) {
+            return null;
+        }
+
+        // Cache key based on the API key to handle key changes
+        $cacheKey = 'stripe-account-id-' . md5($apiKey);
+
+        return Craft::$app->getCache()->getOrSet($cacheKey, function() {
+            try {
+                $account = $this->getClient()->accounts->retrieve();
+                return $account->id;
+            } catch (\Exception $e) {
+                Craft::warning("Failed to retrieve Stripe account ID: {$e->getMessage()}", 'stripe');
+                return null;
+            }
+        }, 86400); // Cache for 24 hours
+    }
+
+    /**
      * Prepares expand params for use with fetchAll.
      * When fetching lists (all), expand params need to be prepended with 'data.'.
      * https://docs.stripe.com/api/expanding_objects


### PR DESCRIPTION
### Description

No need for 'live' in the URL, also will link right to the account for the API Key used without depending on redirects.

### Related issues

#100