### PR TITLE
Add support for cancellation params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Stripe
 
+## Unreleased
+
+- `craft\stripe\services\Subscriptions::cancelSubscriptionByStripeId()` now has an optional `$params` argument, which can be used to pass additional parameters to the Stripe API.
+- `craft\stripe\services\Subscriptions::resumeSubscriptionByStripeId()` now has an optional `$params` argument, which can be used to pass additional parameters to the Stripe API.
+
 ## 1.7.2 - 2026-07-02
 
 - Fixed a [high-severity](https://github.com/craftcms/cms/security/policy#severity--remediation) SQL injection vulnerability. (HCKRT-1509)

--- a/src/services/Subscriptions.php
+++ b/src/services/Subscriptions.php
@@ -345,21 +345,22 @@ class Subscriptions extends Component
      *
      * @param string $stripeId
      * @param bool $immediately
+     * @param array|null $params Additional parameters to send to the Stripe API when cancelling the subscription
      * @return bool
      * @throws \Throwable
      * @throws \yii\db\StaleObjectException
      */
-    public function cancelSubscriptionByStripeId(string $stripeId, bool $immediately = false): bool
+    public function cancelSubscriptionByStripeId(string $stripeId, bool $immediately = false, ?array $params = null): bool
     {
         $stripe = Plugin::getInstance()->getApi()->getClient();
 
         try {
             if ($immediately) {
-                $subscription = $stripe->subscriptions->cancel($stripeId);
+                $subscription = $stripe->subscriptions->cancel($stripeId, $params);
             } else {
-                $subscription = $stripe->subscriptions->update($stripeId, [
+                $subscription = $stripe->subscriptions->update($stripeId, array_merge($params ?? [], [
                     'cancel_at_period_end' => true,
-                ]);
+                ]));
             }
             Plugin::getInstance()->getSubscriptions()->createOrUpdateSubscription($subscription);
         } catch (\Exception $exception) {

--- a/src/services/Subscriptions.php
+++ b/src/services/Subscriptions.php
@@ -375,19 +375,20 @@ class Subscriptions extends Component
      * Resumes subscription by Stripe id.
      *
      * @param string $stripeId
+     * @param array|null $params Additional parameters to send to the Stripe API when resuming the subscription
      * @return bool
      * @throws \Throwable
      * @throws \yii\db\StaleObjectException
      * @since 1.5.0
      */
-    public function resumeSubscriptionByStripeId(string $stripeId): bool
+    public function resumeSubscriptionByStripeId(string $stripeId, ?array $params = null): bool
     {
         $stripe = Plugin::getInstance()->getApi()->getClient();
 
         try {
-            $subscription = $stripe->subscriptions->update($stripeId, [
+            $subscription = $stripe->subscriptions->update($stripeId, array_merge($params ?? [], [
                 'cancel_at_period_end' => false,
-            ]);
+            ]));
             Plugin::getInstance()->getSubscriptions()->createOrUpdateSubscription($subscription);
         } catch (\Exception $exception) {
             Craft::error($exception->getMessage(), 'stripe');


### PR DESCRIPTION
When I implemented cancellation reasons for Craftnet I apparently hallucinated how this method works. I wish I could blame AI, but I don't think this one was all me. 

While I was in there I updated `resumeSubscriptionByStripeId` to accept params as well